### PR TITLE
Refactored elasticsearch

### DIFF
--- a/willow-servers/src/main/java/com/nitorcreations/willow/metrics/AccessLogMetric.java
+++ b/willow-servers/src/main/java/com/nitorcreations/willow/metrics/AccessLogMetric.java
@@ -6,8 +6,6 @@ import java.util.Map;
 
 import javax.inject.Named;
 
-import org.elasticsearch.client.Client;
-
 import com.nitorcreations.willow.messages.AccessLogEntry;
 import com.nitorcreations.willow.messages.metrics.MetricConfig;
 
@@ -35,7 +33,7 @@ public class AccessLogMetric extends FullMessageMultiseriesMetric<AccessLogEntry
   private ValueGetter getter = DURATION;
 
   @Override
-  public Collection<SeriesData<Long, Long>> calculateMetric(Client client, MetricConfig conf) {
+  public Collection<SeriesData<Long, Long>> calculateMetric(MetricConfig conf) {
     if (conf.getLimits().length > 0) {
       limitValues = new long[conf.getLimits().length];
       for (int i = 0; i < conf.getLimits().length; i++) {
@@ -47,7 +45,7 @@ public class AccessLogMetric extends FullMessageMultiseriesMetric<AccessLogEntry
         limitValues = new long[] { 200L, 300L, 400L, 500L, 600L };
       }
     }
-    return super.calculateMetric(client, conf);
+    return super.calculateMetric(conf);
   }
 
   @Override

--- a/willow-servers/src/main/java/com/nitorcreations/willow/metrics/AvailableMetricsMetric.java
+++ b/willow-servers/src/main/java/com/nitorcreations/willow/metrics/AvailableMetricsMetric.java
@@ -9,8 +9,6 @@ import java.util.logging.Logger;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.elasticsearch.client.Client;
-
 import com.nitorcreations.willow.messages.metrics.MetricConfig;
 
 @Named("/available")
@@ -20,14 +18,14 @@ public class AvailableMetricsMetric implements Metric {
   private transient Map<String, Metric> metrics;
 
   @Override
-  public Object calculateMetric(Client client, MetricConfig conf) {
+  public Object calculateMetric(MetricConfig conf) {
     HashMap<String, Boolean> ret = new HashMap<String, Boolean>();
     for (Entry<String, Metric> next : metrics.entrySet()) {
       Class<? extends Metric> nextClass = next.getValue().getClass();
       if (nextClass != this.getClass()) {
         try {
           Metric m = nextClass.newInstance();
-          ret.put(next.getKey(), m.hasData(client, conf));
+          ret.put(next.getKey(), m.hasData(conf));
         } catch (InstantiationException | IllegalAccessException e) {
           log.log(Level.FINE, "Failed to create metric", e);
         }
@@ -37,7 +35,7 @@ public class AvailableMetricsMetric implements Metric {
   }
 
   @Override
-  public boolean hasData(Client client, MetricConfig conf) {
+  public boolean hasData(MetricConfig conf) {
     return true;
   }
 

--- a/willow-servers/src/main/java/com/nitorcreations/willow/metrics/DiskStatusMetric.java
+++ b/willow-servers/src/main/java/com/nitorcreations/willow/metrics/DiskStatusMetric.java
@@ -10,7 +10,6 @@ import javax.inject.Named;
 
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
@@ -24,7 +23,7 @@ import com.nitorcreations.willow.messages.metrics.MetricConfig;
 public class DiskStatusMetric extends AbstractMetric<List<SeriesData<String, Long>>> {
 
   @Override
-  public List<SeriesData<String, Long>> calculateMetric(Client client, MetricConfig conf) {
+  public List<SeriesData<String, Long>> calculateMetric(MetricConfig conf) {
     SearchRequestBuilder builder = client.prepareSearch(MetricUtils.getIndexes(conf.getStart(), conf.getStop(), client)).setTypes(getType()).addField("timestamp").addField("name").addField("total").addField("free").setSize(50).addSort("timestamp", SortOrder.DESC);
     BoolQueryBuilder query = QueryBuilders.boolQuery().must(QueryBuilders.rangeQuery("timestamp").from(conf.getStart()).to(conf.getStop()));
     for (String tag : conf.getTags()) {

--- a/willow-servers/src/main/java/com/nitorcreations/willow/metrics/FullMessageMetric.java
+++ b/willow-servers/src/main/java/com/nitorcreations/willow/metrics/FullMessageMetric.java
@@ -6,7 +6,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.search.SearchHit;
 
 import com.google.gson.Gson;
@@ -32,8 +31,8 @@ public abstract class FullMessageMetric<T extends AbstractMessage, R> extends Ab
     }
   }
   @Override
-  public R calculateMetric(Client client, MetricConfig conf) {
-    SearchResponse response = executeQuery(client, conf, MessageMapping.map(type).lcName(), Collections.<String>emptyList(), getCustomizer());
+  public R calculateMetric(MetricConfig conf) {
+    SearchResponse response = executeQuery(conf, MessageMapping.map(type).lcName(), Collections.<String>emptyList(), getCustomizer());
     readResponse(response);
     return processData(conf.getStart(), conf.getStop(), conf.getStep(), conf);
   }

--- a/willow-servers/src/main/java/com/nitorcreations/willow/metrics/Metric.java
+++ b/willow-servers/src/main/java/com/nitorcreations/willow/metrics/Metric.java
@@ -1,10 +1,8 @@
 package com.nitorcreations.willow.metrics;
 
-import org.elasticsearch.client.Client;
-
 import com.nitorcreations.willow.messages.metrics.MetricConfig;
 
 public interface Metric {
-  Object calculateMetric(Client client, MetricConfig conf);
-  boolean hasData(Client client, MetricConfig conf);
+  Object calculateMetric(MetricConfig conf);
+  boolean hasData(MetricConfig conf);
 }

--- a/willow-servers/src/main/java/com/nitorcreations/willow/metrics/SimpleMetric.java
+++ b/willow-servers/src/main/java/com/nitorcreations/willow/metrics/SimpleMetric.java
@@ -9,7 +9,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitField;
 
@@ -45,7 +44,7 @@ public abstract class SimpleMetric<L extends Comparable, T> extends AbstractMetr
   }
 
   @Override
-  public List<TimePoint<L>> calculateMetric(Client client, MetricConfig conf) {
+  public List<TimePoint<L>> calculateMetric(MetricConfig conf) {
     List<String> fields = new ArrayList<String>();
     fields.add("timestamp");
     fields.addAll(Arrays.asList(requiresFields()));

--- a/willow-servers/src/main/java/com/nitorcreations/willow/metrics/TagListMetric.java
+++ b/willow-servers/src/main/java/com/nitorcreations/willow/metrics/TagListMetric.java
@@ -3,6 +3,8 @@ package com.nitorcreations.willow.metrics;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
+
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
@@ -15,12 +17,14 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import com.nitorcreations.willow.messages.metrics.MetricConfig;
 
 public abstract class TagListMetric implements Metric {
+  @Inject
+  protected Client client;
   private final String tagPrefix;
   public TagListMetric(String tagPrefix) {
     this.tagPrefix = tagPrefix;
   }
   @Override
-  public List<String> calculateMetric(Client client, MetricConfig conf) {
+  public List<String> calculateMetric(MetricConfig conf) {
     SearchRequestBuilder builder = client.prepareSearch(MetricUtils.getIndexes(conf.getStart(), conf.getStop(), client))
       .setTypes(conf.getTypes())
         .setSize(1000).addAggregation(AggregationBuilders.terms("tags")
@@ -42,7 +46,7 @@ public abstract class TagListMetric implements Metric {
     }
     return ret;
   }
-  public boolean hasData(Client client, MetricConfig conf) {
+  public boolean hasData(MetricConfig conf) {
     return true;
   }
 }

--- a/willow-servers/src/main/java/com/nitorcreations/willow/servers/ElasticSearchModule.java
+++ b/willow-servers/src/main/java/com/nitorcreations/willow/servers/ElasticSearchModule.java
@@ -3,6 +3,7 @@ package com.nitorcreations.willow.servers;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 
+import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
@@ -12,9 +13,9 @@ import com.google.inject.AbstractModule;
 import com.nitorcreations.willow.utils.HostUtil;
 
 public class ElasticSearchModule extends AbstractModule {
-
-  @Override
-  protected void configure() {
+  private final Node node;
+  private final Client client;
+  public ElasticSearchModule() {
     ImmutableSettings.Builder settingsBuilder = ImmutableSettings.settingsBuilder();
     String nodeName = System.getProperty("node.name", HostUtil.getHostName());
     if (nodeName == null || nodeName.isEmpty() || "localhost".equals(nodeName)) {
@@ -28,10 +29,29 @@ public class ElasticSearchModule extends AbstractModule {
       settingsBuilder.put("http.port", Integer.parseInt(httpPort));
     }
     Settings settings = settingsBuilder.build();
-    Node node = NodeBuilder.nodeBuilder().settings(settings).clusterName(System.getProperty("elasticsearch.cluster.name", "willowmetrics")).data(true).local(true).node();
-    bind(Node.class).toInstance(node);
+    String clusterName = System.getProperty("elasticsearch.cluster.name");
+    NodeBuilder builder = NodeBuilder.nodeBuilder().settings(settings);
+    if (clusterName == null) {
+      builder.clusterName("willowmetrics").data(true).local(true);
+    } else {
+      builder.clusterName(clusterName).data(false).client(true).local(false);
+    }
+    node = builder.node();
+    client = node.client();
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        client.close();
+        node.close();
+      }
+    });
+  }
+  @Override
+  protected void configure() {
+    bind(Client.class).toInstance(client);
   }
   public String randomNodeId() {
     return new BigInteger(130, new SecureRandom()).toString(32);
   }
+  
 }

--- a/willow-servers/src/main/java/com/nitorcreations/willow/servers/HostInfoHostLookupService.java
+++ b/willow-servers/src/main/java/com/nitorcreations/willow/servers/HostInfoHostLookupService.java
@@ -54,7 +54,7 @@ public class HostInfoHostLookupService implements HostLookupService {
     long now = System.currentTimeMillis();
     metricConfig.setStart(now - 90000);
     metricConfig.setStop(now);
-    return hostInfoMetric.calculateMetric(node.client(), metricConfig);
+    return hostInfoMetric.calculateMetric(metricConfig);
   }
 
   @Override

--- a/willow-servers/src/main/java/com/nitorcreations/willow/servers/HostInfoHostLookupService.java
+++ b/willow-servers/src/main/java/com/nitorcreations/willow/servers/HostInfoHostLookupService.java
@@ -1,22 +1,17 @@
 package com.nitorcreations.willow.servers;
 
-import java.util.Collection;
-import java.util.logging.Logger;
-
-import javax.inject.Inject;
-
-import org.elasticsearch.node.Node;
-
 import com.nitorcreations.willow.messages.HostInfoMessage;
 import com.nitorcreations.willow.messages.metrics.MetricConfig;
 import com.nitorcreations.willow.metrics.HostInfoMetric;
+
+import javax.inject.Inject;
+import java.util.Collection;
+import java.util.logging.Logger;
 
 public class HostInfoHostLookupService implements HostLookupService {
 
   private Logger logger = Logger.getLogger(this.getClass().getCanonicalName());
 
-  @Inject
-  Node node;
   @Inject
   HostInfoMetric hostInfoMetric;
 

--- a/willow-servers/src/main/java/com/nitorcreations/willow/servers/SaveEventsSocket.java
+++ b/willow-servers/src/main/java/com/nitorcreations/willow/servers/SaveEventsSocket.java
@@ -16,7 +16,6 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.node.Node;
 
 import com.google.gson.Gson;
 import com.nitorcreations.willow.messages.AbstractMessage;
@@ -32,7 +31,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class SaveEventsSocket extends BasicWillowSocket {
   private final MessageMapping mapping = new MessageMapping();
   @Inject
-  private Node node;
+  private Client client;
   private String path;
   private List<String> tags;
 
@@ -53,7 +52,7 @@ public class SaveEventsSocket extends BasicWillowSocket {
   @SuppressFBWarnings(value={"BC_UNCONFIRMED_CAST_OF_RETURN_VALUE"}, justification="Messagetype encoded in the message used to determine type")
   @OnWebSocketMessage
   public void messageReceived(byte buf[], int offset, int length) {
-    try (Client client = node.client()){
+    try {
       Gson gson = new Gson();
       for (AbstractMessage msgObject : mapping.decode(buf, offset, length)) {
         MessageType type = MessageMapping.map(msgObject.getClass());

--- a/willow-servers/src/main/java/com/nitorcreations/willow/servers/ServerSidePollingSocket.java
+++ b/willow-servers/src/main/java/com/nitorcreations/willow/servers/ServerSidePollingSocket.java
@@ -57,7 +57,7 @@ public class ServerSidePollingSocket extends BasicWillowSocket {
         long stop = System.currentTimeMillis() - currTimeDelay;
         long start = stop - conf.getStep();
         Metric nextMetric = metric.getClass().newInstance();
-        Object ret = nextMetric.calculateMetric(client, conf);
+        Object ret = nextMetric.calculateMetric(conf);
         conf.setStop(stop);
         conf.setStart(start);
         session.getRemote().sendString(gson.toJson(ret));


### PR DESCRIPTION
We now share elasticsearch client via an injected field instead of from the metricsservlet and injected node. This is more how the client is meant to be used. Also if clustername is defined, we create just a client with no data to join existing elasticsearch cluster.